### PR TITLE
Matched devices fix

### DIFF
--- a/lib/rubotium/devices.rb
+++ b/lib/rubotium/devices.rb
@@ -8,7 +8,7 @@ module Rubotium
 
     def all
       raise NoDevicesError if attached_devices.empty?
-      raise NoMatchedDevicesError if matched_devices.empty?
+      raise NoMatchedDevicesError if matched_devices.nil? or matched_devices.empty?
       matched_devices
     end
 

--- a/lib/rubotium/devices.rb
+++ b/lib/rubotium/devices.rb
@@ -17,7 +17,7 @@ module Rubotium
     attr_reader :matched, :attached_devices, :match_name, :match_serial, :match_sdk
 
     def matched_devices
-      @matched_devices ||=(matched_by_name + matched_by_serial + matched_by_sdk).uniq
+      @matched_devices ||=[matched_by_name, matched_by_serial, matched_by_sdk].reject( &:empty? ).reduce( :& )
     end
 
     def attached_devices


### PR DESCRIPTION
Fix matched_devices to match on all specified criteria (e.g. and) instead of any specified criteria (e.g. or).
Handle cases were one or more matching categories have not been specified.