### PR TITLE
Support helper application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.idea
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .bundle
 .config
 .yardoc
-.idea
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/bin/rubotium
+++ b/bin/rubotium
@@ -13,6 +13,7 @@ opts = Trollop::options do
     opt :sdk,             'Run on devices with sdk',      :type     => :string,       :short  =>  '-k'
     opt :runner,          'Test runner',                  :type     => :string,       :short  =>  '-r'
     opt :annotation,      'Run annotated tests',          :type     => :string,       :short  =>  '-n'
+    opt :helper_apk_path, 'Path to the helper .apk file', :type     => :string,       :short  =>  '-H'
 end
 
 params = {
@@ -24,7 +25,8 @@ params = {
     :device_matcher     => opts[:device],
     :device_sdk         => opts[:sdk],
     :runner             => opts[:runner],
-    :annotation         => opts[:annotation]
+    :annotation         => opts[:annotation],
+    :helper_apk_path    => opts[:helper_apk_path]
 }
 
 Rubotium.new(params)

--- a/lib/rubotium.rb
+++ b/lib/rubotium.rb
@@ -55,6 +55,7 @@ module Rubotium
 
       application_package = Rubotium::Package.new(opts[:app_apk_path])
       tests_package       = Rubotium::Package.new(opts[:tests_apk_path], opts[:runner])
+      helper_package      = Rubotium::Package.new(opts[:helper_apk_path])
 
       devices = Devices.new(:name => opts[:device_matcher], :sdk => opts[:device_sdk]).all
 
@@ -63,6 +64,10 @@ module Rubotium
         device.install application_package.path
         device.uninstall tests_package.name
         device.install tests_package.path
+        if !opts[:helper_apk_path].nil?
+          device.uninstall helper_package.name
+          device.install helper_package.path
+        end
         device.shell('mkdir /sdcard/screencasts')
         device
       }

--- a/lib/rubotium.rb
+++ b/lib/rubotium.rb
@@ -40,6 +40,9 @@ module Rubotium
       raise RuntimeError,   "Empty configuration"       if opts.empty?
       raise Errno::ENOENT,  "Tests apk does not exist"  if !File.exist?(opts[:tests_apk_path])
       raise Errno::ENOENT,  "App apk does not exist"    if !File.exist?(opts[:app_apk_path])
+      if !opts[:helper_apk_path].nil?
+        raise Errno::ENOENT,  "Helper apk does not exist" if !File.exist?(opts[:helper_apk_path])
+      end
 
       logger.level = Logger::INFO
 


### PR DESCRIPTION
Support un/installation of another (optional) application that can be used as a helper app while running tests.